### PR TITLE
Update the existing boolean attributes pattern

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -96,9 +96,12 @@ export default function r2wc<Props, Context>(
         const type = propTypes[prop]
         const transform = transforms[type]
 
-        if (value && transform?.parse) {
+        if (!value && type === "boolean") {
           //@ts-ignore
-          this[propsSymbol][prop] = transform.parse(value, this)
+          this[propsSymbol][prop] = true
+        } else if (value && transform?.parse) {
+          //@ts-ignore
+          this[propsSymbol][prop] = transform.parse(value, attribute, this)
         }
       }
     }
@@ -126,8 +129,13 @@ export default function r2wc<Props, Context>(
       const transform = transforms[type]
 
       if (prop in propTypes && transform?.parse) {
-        //@ts-ignore
-        this[propsSymbol][prop] = transform.parse(value, this)
+        if (!value && type === "boolean") {
+          //@ts-ignore
+          this[propsSymbol][prop] = true
+        } else {
+          //@ts-ignore
+          this[propsSymbol][prop] = transform.parse(value, attribute, this)
+        }
 
         this[renderSymbol]()
       }

--- a/packages/core/src/transforms/boolean.ts
+++ b/packages/core/src/transforms/boolean.ts
@@ -1,8 +1,27 @@
 import type { Transform } from "./index"
 
+let LOG_DEPRECATION_WARNING = true
 const string: Transform<boolean> = {
   stringify: (value) => (value ? "true" : "false"),
-  parse: (value) => /^[ty1-9]/i.test(value),
+  parse: (value, attribute) => {
+    const trueRegex = new RegExp(`^\b(true|${attribute})\b$`, "gi")
+    const falseRegex = new RegExp(`^\bfalse\b$`, "gi")
+    const deprecatedRegex = new RegExp(`^[ty1-9]`, "gi")
+
+    if (trueRegex.test(value)) {
+      return true
+    } else if (falseRegex.test(value)) {
+      return false
+    } else {
+      if (LOG_DEPRECATION_WARNING) {
+        console.warn(
+          `[${attribute}="${value}"] The current pattern for boolean attributes has been marked as deprecated, but it is still supported in this release. In a future release, this pattern will no longer be supported. To avoid compatibility issues, please migrate to the new behavior and use the attribute without a value or pass 'true', '<attribute>', or an empty string for the value to represent true. Otherwise, the attribute will be considered false.`,
+        )
+        LOG_DEPRECATION_WARNING = false
+      }
+      return deprecatedRegex.test(value)
+    }
+  },
 }
 
 export default string

--- a/packages/core/src/transforms/function.ts
+++ b/packages/core/src/transforms/function.ts
@@ -2,7 +2,7 @@ import type { Transform } from "./index"
 
 const string: Transform<(...args: unknown[]) => unknown> = {
   stringify: (value) => value.name,
-  parse: (value, element) => {
+  parse: (value, _, element) => {
     const fn = (() => {
       if (typeof window !== "undefined" && value in window) {
         // @ts-expect-error

--- a/packages/core/src/transforms/index.ts
+++ b/packages/core/src/transforms/index.ts
@@ -6,7 +6,7 @@ import json from "./json"
 
 export interface Transform<Type> {
   stringify?: (value: Type) => string
-  parse: (value: string, element: HTMLElement) => Type
+  parse: (value: string, attribute: string, element: HTMLElement) => Type
 }
 
 const transforms = {


### PR DESCRIPTION
The existing regex pattern for boolean attributes is far from the DOM specs.

So this PR modifies this pattern to be as follows:
**Checked:**

- `<my-component checked />`
- `<my-component checked="" />`
- `<my-component checked="checked" />`
- `<my-component checked="true" />`

**Unchecked:**

- `<my-component />`
- `<my-component checked="false" />`

Otherwise, use existing behavior and log a warning to the user that this behavior is deprecated