### PR TITLE
Fix to allow the DOM element to be removed and readded

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -113,8 +113,8 @@ export default function r2wc<Props, Context>(
 
       if (this[contextSymbol]) {
         renderer.unmount(this[contextSymbol])
+        delete this[contextSymbol]
       }
-      delete this[contextSymbol]
     }
 
     attributeChangedCallback(

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -114,6 +114,7 @@ export default function r2wc<Props, Context>(
       if (this[contextSymbol]) {
         renderer.unmount(this[contextSymbol])
       }
+      delete this[contextSymbol]
     }
 
     attributeChangedCallback(

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -114,6 +114,7 @@ export default function r2wc<Props, Context>(
       if (this[contextSymbol]) {
         renderer.unmount(this[contextSymbol])
       }
+      delete this[contextSymbol]
     }
 
     attributeChangedCallback(
@@ -164,7 +165,7 @@ export default function r2wc<Props, Context>(
         const transform = transforms[type]
         if (transform?.stringify) {
           //@ts-ignore
-          const attributeValue = transform.stringify(value)
+          const attributeValue = type === "function" ? value : transform.stringify(value)
           const oldAttributeValue = this.getAttribute(attribute)
 
           if (oldAttributeValue !== attributeValue) {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -114,7 +114,6 @@ export default function r2wc<Props, Context>(
       if (this[contextSymbol]) {
         renderer.unmount(this[contextSymbol])
       }
-      delete this[contextSymbol]
     }
 
     attributeChangedCallback(

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -165,7 +165,7 @@ export default function r2wc<Props, Context>(
         const transform = transforms[type]
         if (transform?.stringify) {
           //@ts-ignore
-          const attributeValue = type === "function" ? value : transform.stringify(value)
+          const attributeValue = transform.stringify(value)
           const oldAttributeValue = this.getAttribute(attribute)
 
           if (oldAttributeValue !== attributeValue) {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -113,8 +113,8 @@ export default function r2wc<Props, Context>(
 
       if (this[contextSymbol]) {
         renderer.unmount(this[contextSymbol])
-        delete this[contextSymbol]
       }
+      delete this[contextSymbol]
     }
 
     attributeChangedCallback(


### PR DESCRIPTION
This is a pull request for a fix that was suggested in the issues https://github.com/bitovi/react-to-web-component/issues/113. It allows the root DOM node to be moved or removed and added. 

Prevents the error "Cannot update an unmounted root."

To replicate remove the root DOM element then re add it.