### PR TITLE
Change r2wc externals to match react-dom/client

### DIFF
--- a/packages/react-to-web-component/vite.config.ts
+++ b/packages/react-to-web-component/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
       formats: ["es", "cjs"],
     },
     rollupOptions: {
-      external: ["react", "react-dom", "@r2wc/core"],
+      external: ["react", "react-dom/client", "@r2wc/core"],
     },
   },
   plugins: [dts()],


### PR DESCRIPTION
r2wc 2.0.2 changed to importing and using react-dom/client instead of react-dom as part of upgrading to use React 18.2.  However the vite externals were not updated to reflect this, so the builds contained react-dom/client and still referenced react-dom as an external.  This is a quick fix to update vite.config.ts to reflect the change in dependencies.