### PR TITLE
Update README with new file size for the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 `@r2wc/react-to-web-component`:
 
 - Works in all modern browsers. (Edge needs a [customElements polyfill](https://github.com/webcomponents/polyfills/tree/master/packages/custom-elements)).
-- Is `1.26KB` minified and gzipped.
+- Is `1.36KB` minified and gzipped.
 
 ## Setup
 


### PR DESCRIPTION
With some new features comes a new file size.  It's still tiny when minified/gzipped but about 100 more bytes than before.